### PR TITLE
Outlier semver detection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.12 // indirect
 	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/andrewchambers/go-jqpipe v0.0.0-20180509223707-2d54cef8cd94 // indirect
-	github.com/blang/semver v3.5.1+incompatible // indirect
+	github.com/blang/semver v3.5.1+incompatible
 	github.com/containerd/continuity v0.0.0-20181203112020-004b46473808 // indirect
 	github.com/docker/distribution v2.7.1+incompatible // indirect
 	github.com/docker/docker v1.13.1

--- a/go.sum
+++ b/go.sum
@@ -98,6 +98,7 @@ github.com/beorn7/perks v1.0.0/go.mod h1:KWe93zE9D1o94FZ5RNwFwVgaQK1VOXiVxmqh+Ce
 github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d/go.mod h1:6QX/PXZ00z/TKoufEY6K/a0k6AhaJrQKdFe6OfVXsa4=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bitly/go-hostpool v0.0.0-20171023180738-a3a6125de932/go.mod h1:NOuUCSz6Q9T7+igc/hlvDOUdtWKryOrtFyIVABv/p7k=
+github.com/blang/semver v3.5.1+incompatible h1:cQNTCjp13qL8KC3Nbxr/y2Bqb63oX6wdnnjpJbkM4JQ=
 github.com/blang/semver v3.5.1+incompatible/go.mod h1:kRBLl5iJ+tD4TcOOxsy/0fnwebNt5EWlYSAyrTnjyyk=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=

--- a/pkg/outdated/outdated.go
+++ b/pkg/outdated/outdated.go
@@ -42,7 +42,10 @@ func (o Outdated) ParseImage(image string, pullableImage string) (*CheckResult, 
 		return nil, errors.Wrap(err, "failed to fetch image tags")
 	}
 
-	semverTags, nonSemverTags := parseTags(tags)
+	semverTags, nonSemverTags, err := parseTags(tags)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to parse tags")
+	}
 
 	detectedSemver, err := semver.NewVersion(tag)
 	if err != nil {

--- a/pkg/outdated/registry.go
+++ b/pkg/outdated/registry.go
@@ -19,8 +19,8 @@ import (
 const (
 	// SemverOutlierMajorVersionThreshold defines the number of major versions that must be skipped before
 	// the next version is considered an outlier
-	// setting this to 1 allows NO major versions to be skipped
-	SemverOutlierMajorVersionThreshold = 1
+	// setting this to 2 allows only 1 major version to be skipped
+	SemverOutlierMajorVersionThreshold = 2
 )
 
 type DockerConfig struct {

--- a/pkg/outdated/registry.go
+++ b/pkg/outdated/registry.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"sort"
 	"strings"
 	"time"
 
@@ -13,6 +14,13 @@ import (
 	"github.com/genuinetools/reg/registry"
 	semver "github.com/hashicorp/go-version"
 	"github.com/pkg/errors"
+)
+
+const (
+	// SemverOutlierMajorVersionThreshold defines the number of major versions that must be skipped before
+	// the next version is considered an outlier
+	// setting this to 1 allows NO major versions to be skipped
+	SemverOutlierMajorVersionThreshold = 1
 )
 
 type DockerConfig struct {
@@ -92,7 +100,7 @@ func fetchTags(reg *registry.Registry, imageName string) ([]string, error) {
 	return tags, nil
 }
 
-func parseTags(tags []string) ([]*semver.Version, []string) {
+func parseTags(tags []string) ([]*semver.Version, []string, error) {
 	semverTags := make([]*semver.Version, 0, 0)
 	nonSemverTags := make([]string, 0, 0)
 
@@ -105,7 +113,48 @@ func parseTags(tags []string) ([]*semver.Version, []string) {
 		}
 	}
 
-	return semverTags, nonSemverTags
+	// some semver tags might be outliers and should be treated as non-semver tags
+	// For more info, see https://github.com/replicatedhq/outdated/issues/19
+	outlierSemver, remainingSemver, err := splitOutlierSemvers(semverTags)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to split outliers")
+	}
+
+	for _, outlier := range outlierSemver {
+		nonSemverTags = append(nonSemverTags, outlier.String())
+	}
+
+	return remainingSemver, nonSemverTags, nil
+}
+
+func splitOutlierSemvers(allSemverTags []*semver.Version) ([]*semver.Version, []*semver.Version, error) {
+	if len(allSemverTags) == 0 {
+		return []*semver.Version{}, []*semver.Version{}, nil
+	}
+
+	sortable := SemverTagCollection(allSemverTags)
+	sort.Sort(sortable)
+
+	outliers := []*semver.Version{}
+	remaining := []*semver.Version{}
+
+	lastVersion := allSemverTags[0]
+	isInOutlier := false
+	for _, v := range allSemverTags {
+		if v.Segments()[0]-lastVersion.Segments()[0] > SemverOutlierMajorVersionThreshold {
+			isInOutlier = true
+		}
+
+		if isInOutlier {
+			outliers = append(outliers, v)
+		} else {
+			remaining = append(remaining, v)
+		}
+
+		lastVersion = v
+	}
+
+	return outliers, remaining, nil
 }
 
 func homeDir() string {

--- a/pkg/outdated/registry_test.go
+++ b/pkg/outdated/registry_test.go
@@ -1,0 +1,85 @@
+package outdated
+
+import (
+	"testing"
+
+	semver "github.com/hashicorp/go-version"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_SplitStringOnLen(t *testing.T) {
+	tests := []struct {
+		name              string
+		allSemverTags     []string
+		expectedOutliers  []string
+		expectedRemaining []string
+	}{
+		{
+			name: "elasticsearch",
+			allSemverTags: []string{
+				"0.0.1",
+				"0.0.2",
+				"0.8-alpha4",
+				"1.0.0",
+				"1.0.1",
+				"43.0.0",
+			},
+			expectedOutliers: []string{
+				"43.0.0",
+			},
+			expectedRemaining: []string{
+				"0.0.1",
+				"0.0.2",
+				"0.8-alpha4",
+				"1.0.0",
+				"1.0.1",
+			},
+		},
+		{
+			name: "no outliers",
+			allSemverTags: []string{
+				"0.0.1",
+				"1.0.0",
+				"2.0.0",
+				"4.0.1",
+			},
+			expectedOutliers: []string{
+				"4.0.1",
+			},
+			expectedRemaining: []string{
+				"0.0.1",
+				"1.0.0",
+				"2.0.0",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			req := require.New(t)
+
+			allSemvers := []*semver.Version{}
+			for _, s := range test.allSemverTags {
+				v := semver.Must(semver.NewVersion(s))
+				allSemvers = append(allSemvers, v)
+			}
+
+			actualOutliers, actualRemaining, err := splitOutlierSemvers(allSemvers)
+			req.NoError(err)
+
+			actualOutliersStrings := []string{}
+			for _, a := range actualOutliers {
+				actualOutliersStrings = append(actualOutliersStrings, a.Original())
+			}
+
+			actualRemainingStrings := []string{}
+			for _, a := range actualRemaining {
+				actualRemainingStrings = append(actualRemainingStrings, a.Original())
+			}
+
+			assert.Equal(t, test.expectedOutliers, actualOutliersStrings)
+			assert.Equal(t, test.expectedRemaining, actualRemainingStrings)
+		})
+	}
+}

--- a/pkg/outdated/registry_test.go
+++ b/pkg/outdated/registry_test.go
@@ -44,8 +44,75 @@ func Test_SplitStringOnLen(t *testing.T) {
 				"2.0.0",
 				"4.0.1",
 			},
-			expectedOutliers: []string{
+			expectedOutliers: []string{},
+			expectedRemaining: []string{
+				"0.0.1",
+				"1.0.0",
+				"2.0.0",
 				"4.0.1",
+			},
+		},
+		{
+
+			name: "just barely an outlier",
+			allSemverTags: []string{
+				"0.0.1",
+				"1.0.0",
+				"2.0.0",
+				"3.0.1",
+				"5.0.0-beta",
+				"8.0.0",
+			},
+			expectedOutliers: []string{
+				"8.0.0",
+			},
+			expectedRemaining: []string{
+				"0.0.1",
+				"1.0.0",
+				"2.0.0",
+				"3.0.1",
+				"5.0.0-beta",
+			},
+		},
+		{
+			name: "multiple spread outliers",
+			allSemverTags: []string{
+				"0.0.1",
+				"1.0.0",
+				"2.0.0",
+				"4.0.1",
+				"7.0.0",
+				"11.0.0",
+			},
+			expectedOutliers: []string{
+				"7.0.0",
+				"11.0.0",
+			},
+			expectedRemaining: []string{
+				"0.0.1",
+				"1.0.0",
+				"2.0.0",
+				"4.0.1",
+			},
+		},
+		{
+			name: "multiple ranges",
+			allSemverTags: []string{
+				"0.0.1",
+				"1.0.0",
+				"2.0.0",
+				"7.0.1",
+				"7.0.2",
+				"7.0.3",
+				"11.0.0",
+				"12.0-beta",
+			},
+			expectedOutliers: []string{
+				"7.0.1",
+				"7.0.2",
+				"7.0.3",
+				"11.0.0",
+				"12.0-beta",
 			},
 			expectedRemaining: []string{
 				"0.0.1",


### PR DESCRIPTION
This fixes #19  but doesn't have a lot of error room.

Open to suggestions for better thresholds here.

The problem is summarized by: Elasticsearch has a lot of tags of their image (see list at the bottom of this message). It's very easy to split this into semver and non-semver. But what is that 43.0.0 doing? It's clearly not really semver, and it will always report as a false "newer" version. So this PR looks for Major version gaps and discards anything after a gap.

```
0.0.1
0.0.2
0.8.0-alpha4
0.8.0-alpha5
0.8.0-rc1
0.8.0-rc2
0.8.0-rc3
0.8.0-rc4
0.8.0-rc5
0.8.0-rc6
0.8.0
0.8.1-rc1
0.8.1-rc2
0.8.1
0.9.0-SNAPSHOT-apm
0.9.0-rc2
0.9.0-rc3
0.9.0-rc6
0.9.0-rc7
0.9.0
1.0.0-beta1-bc10
1.0.0-beta1-bc11
1.0.0-beta1-bc12
1.0.0-beta1-bc5
1.0.0-beta1-bc6
1.0.0-beta1-bc7
1.0.0-beta1-bc8
1.0.0-beta1-bc9
1.0.0-beta1
1.0.0-rc3
1.0.0-rc4
1.0.0-rc5
1.0.0-rc6
1.0.0
1.0.1-rc1
1.0.1-rc2
1.0.1
43.0.0
apm
test
```