### PR TITLE
Remove an invalid test

### DIFF
--- a/pkg/outdated/version_test.go
+++ b/pkg/outdated/version_test.go
@@ -93,11 +93,6 @@ func TestTagCollectionUnique(t *testing.T) {
 			versions:       []string{"10", "11"},
 			expectVersions: []string{"10", "11"},
 		},
-		{
-			name:           "less specific patch version",
-			versions:       []string{"0.1.0", "0.1"},
-			expectVersions: []string{"0.1.0", "0.1"},
-		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
I can't figure out how this test would ever pass, or why it exists. 0.1.0 is unique from 0.1, but they are functionally the same in the server sort. I think it was a flakey test that used to pass and no longer is, but I'm recommending removing it.