### PR TITLE
automatically build and test merges to master

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,6 @@ name: build-and-test
 
 on:
   push:
-    branches-ignore:
-      - master
     tags-ignore:
       - "*"
 


### PR DESCRIPTION
Right now it's hard to tell if multiple merges conflict to somehow break tests.

And I don't really see a reason _not_ to test master - is there one?