### PR TITLE
Add support for JSON output format

### DIFF
--- a/pkg/logger/json.go
+++ b/pkg/logger/json.go
@@ -1,0 +1,12 @@
+package logger
+
+type JSONResult struct {
+	Repo  string `json:"repository"`
+	Image string `json:"image"`
+	Tag   string `json:"tag"`
+
+	LatestVersion  string `json:"latestVersion"`
+	VersionsBehind int64  `json:"versionsBehind"`
+
+	Error *string `json:"error,omitempty"`
+}


### PR DESCRIPTION
To use the outdated information in other systems, provide optional JSON output format.

You can give an optional `--output=json` flag and the output will be in JSON format like this

```json
[
  {
    "repository": "docker.io",
    "image": "bitnami/mariadb",
    "tag": "10.5.10-debian-10-r18",
    "latestVersion": "10.5.10-debian-10-r18",
    "versionsBehind": 0
  },
  {
    "repository": "k8s.gcr.io",
    "image": "library/coredns",
    "tag": "1.7.0",
    "latestVersion": "1.7.0",
    "versionsBehind": 0
  },
  {
    "repository": "k8s.gcr.io",
    "image": "library/etcd",
    "tag": "3.4.13-0",
    "latestVersion": "3.4.13-0",
    "versionsBehind": 0
  },
  {
    "repository": "docker.io",
    "image": "kindest/kindnetd",
    "tag": "v20200725-4d6bea59",
    "latestVersion": "20200725.0.0-4d6bea59",
    "versionsBehind": 0
  },
  {
    "repository": "k8s.gcr.io",
    "image": "library/kube-apiserver",
    "tag": "v1.19.1",
    "latestVersion": "1.19.1",
    "versionsBehind": 0
  },
  {
    "repository": "k8s.gcr.io",
    "image": "library/kube-controller-manager",
    "tag": "v1.19.1",
    "latestVersion": "1.19.1",
    "versionsBehind": 0
  },
  {
    "repository": "k8s.gcr.io",
    "image": "library/kube-proxy",
    "tag": "v1.19.1",
    "latestVersion": "1.19.1",
    "versionsBehind": 0
  },
  {
    "repository": "k8s.gcr.io",
    "image": "library/kube-scheduler",
    "tag": "v1.19.1",
    "latestVersion": "1.19.1",
    "versionsBehind": 0
  },
  {
    "repository": "docker.io",
    "image": "rancher/local-path-provisioner",
    "tag": "v0.0.14",
    "latestVersion": "0.0.19",
    "versionsBehind": 5
  }
]
```

Fixes #31 